### PR TITLE
Patch missing error checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 [![Build Status](https://travis-ci.org/speratus/easy-redux-reducers.svg?branch=master)](https://travis-ci.org/speratus/easy-redux-reducers)
 [![codecov](https://codecov.io/gh/speratus/easy-redux-reducers/branch/master/graph/badge.svg)](https://codecov.io/gh/speratus/easy-redux-reducers)
+[![Maintainability](https://api.codeclimate.com/v1/badges/59a7a3e7443baffc3306/maintainability)](https://codeclimate.com/github/speratus/easy-redux-reducers/maintainability)
 # Easy Redux Reducers
 Easy Redux Reducers makes Redux developers' lives easier by enabling them to skip the overhead of writing
 reducers manually. Instead, `easy-redux-reducers` gives developers a simple, clean library to use.
 
-The typical flow for building a redux reducer requires developers to build reducers using switch statements. Generally, developers consider switch statements to be code smells in object oriented code. `redux-reducer-builder` eliminates the need to write switch statements in reducers.
+The typical flow for building a redux reducer requires developers to build reducers using switch statements. Generally, developers consider switch statements to be code smells in object oriented code. `easy-redux-reducers` eliminates the need to write switch statements in reducers.
 
 ## Why use Easy Redux Reducers?
 Imagine we are building a reducer for a scenario in which we have an array of items in which each item is displayed one at a time. Consequently, we will also need a counter to keep track of the position in the array.

--- a/index.js
+++ b/index.js
@@ -1,3 +1,25 @@
+function mapAction(map, action, callback) {
+    switch(typeof action) {
+        case 'object':
+            if (!action.type) {
+                throw new TypeError("action must be a valid action object.")
+            }
+            map[action.type] = callback
+            break
+        case 'function':
+            if (!action().type) {
+                throw new TypeError("action() must return a valid action object.")
+            }
+            map[action().type] = callback
+            break
+        case 'string':
+            map[action] = callback
+            break
+        default:
+            throw new Error("Action must be either an object, function, or a string")
+    }
+}
+
 function generateReducer() {
     let actionMap = {}
     let initialState
@@ -7,19 +29,7 @@ function generateReducer() {
     }
 
     function addAction(action, callback) {
-        switch(typeof action) {
-            case 'object':
-                actionMap[action.type] = callback
-                break
-            case 'function':
-                actionMap[action().type] = callback
-                break
-            case 'string':
-                actionMap[action] = callback
-                break
-            default:
-                throw new Error("Action must be either an object, function or a string")
-        }
+        mapAction(actionMap, action, callback)
     }
 
     function buildReducer() {

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ describe('generateReducer', function() {
 
     describe('addAction', function() {
         it('should return undefined', function() {
-            expect(builder.addAction({}, ()=>{})).to.be(undefined)
+            expect(builder.addAction({type: 'T'}, ()=>{})).to.be(undefined)
         })
 
         it('should throw an error if given improper action type argument', function() {
@@ -48,6 +48,18 @@ describe('generateReducer', function() {
             }
 
             expect(builder.addAction(action, ()=>{})).to.be(undefined)
+        })
+
+        it("should throw an error if given an action object without a type attribute", function() {
+            expect(builder.addAction.bind(this, {}, ()=>{})).to.throwError()
+        })
+
+        it("should throw an error if given an action builder that returns an object without a type attribute", function() {
+            function failure() {
+                return {}
+            }
+
+            expect(builder.addAction.bind(this, failure, ()=>{})).to.throwError()
         })
     })
 


### PR DESCRIPTION
Adds some error checks to prevent the possibility of creating actions that respond to undefined. Additionally, refactors `generateReducer` to be more readable.

## Error description
Previously, it was possible to add an action to the action map such that trying to access the map using a key of `undefined` would return a valid action.
For example:
```js
builder.addAction({}, () => {})
```
Would not raise an error, but would instead add an action to the action map with a key of `undefined`.

The correct behavior would be to notify the developer that they have made an error by trying to add an action that does not have a type attribute.